### PR TITLE
Implement dummy INFO cmd

### DIFF
--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -1,0 +1,16 @@
+use crate::commands::CommandParser;
+use crate::Error;
+
+#[derive(Debug, PartialEq)]
+pub struct Get {
+    pub key: String,
+}
+
+impl TryFrom<&mut CommandParser> for Get {
+    type Error = Error;
+
+    fn try_from(parser: &mut CommandParser) -> Result<Self, Self::Error> {
+        let key = parser.next_string()?;
+        Ok(Self { key })
+    }
+}

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,0 +1,71 @@
+use bytes::Bytes;
+
+use crate::commands::CommandParser;
+use crate::frame::Frame;
+use crate::Error;
+
+const INFO: &str = r#"
+# Server
+redis_version:7.2.4
+os:Linux 5.15.0-1015-aws x86_64
+arch_bits:64
+process_id:1
+uptime_in_seconds:1030110
+tcp_port:6379
+
+# Clients
+connected_clients:1
+maxclients:10000
+
+# Memory
+used_memory:68824640
+used_memory_human:65.64M
+used_memory_peak:68848456
+used_memory_peak_human:65.66M
+maxmemory:4294967296
+maxmemory_human:4.00G
+
+# Persistence
+loading:0
+rdb_changes_since_last_save:1050288
+aof_enabled:0
+
+# Stats
+total_connections_received:21
+total_commands_processed:1308336
+instantaneous_ops_per_sec:0
+
+# Replication
+role:master
+connected_slaves:0
+
+# CPU
+used_cpu_sys:850.545934
+used_cpu_user:1777.532734
+
+# Errorstats
+errorstat_ERR:count:1189
+
+# Cluster
+cluster_enabled:0
+
+# Keyspace
+db0:keys=397255,expires=845,avg_ttl=1527956522210785
+"#;
+
+#[derive(Debug, PartialEq)]
+pub struct Info {}
+
+impl Info {
+    pub async fn apply(self) -> crate::Result<Frame> {
+        Ok(Frame::Bulk(Bytes::from(INFO)))
+    }
+}
+
+impl TryFrom<&mut CommandParser> for Info {
+    type Error = Error;
+
+    fn try_from(parser: &mut CommandParser) -> Result<Self, Self::Error> {
+        Ok(Self {})
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,15 +1,23 @@
+pub mod get;
+pub mod info;
+pub mod set;
+
 use bytes::Bytes;
+use std::{str, vec};
 use thiserror::Error as ThisError;
 
 use crate::frame::Frame;
 use crate::Error;
 
-use std::{str, vec};
+use get::Get;
+use info::Info;
+use set::Set;
 
 #[derive(Debug, PartialEq)]
 pub enum Command {
     Get(Get),
     Set(Set),
+    Info(Info),
 }
 
 impl TryFrom<Frame> for Command {
@@ -22,39 +30,9 @@ impl TryFrom<Frame> for Command {
         match &command_name[..] {
             "get" => Get::try_from(&mut parser).map(Command::Get),
             "set" => Set::try_from(&mut parser).map(Command::Set),
+            "info" => Info::try_from(&mut parser).map(Command::Info),
             name => return Err(format!("protocol error; unknown command {:?}", name).into()),
         }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub struct Get {
-    pub key: String,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct Set {
-    pub key: String,
-    pub value: Bytes,
-}
-
-impl TryFrom<&mut CommandParser> for Get {
-    type Error = Error;
-
-    fn try_from(parser: &mut CommandParser) -> Result<Self, Self::Error> {
-        let key = parser.next_string()?;
-        Ok(Self { key })
-    }
-}
-
-impl TryFrom<&mut CommandParser> for Set {
-    type Error = Error;
-
-    fn try_from(parser: &mut CommandParser) -> Result<Self, Self::Error> {
-        let key = parser.next_string()?;
-        let value = parser.next_bytes()?;
-
-        Ok(Self { key, value })
     }
 }
 

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -1,0 +1,21 @@
+use bytes::Bytes;
+
+use crate::commands::CommandParser;
+use crate::Error;
+
+#[derive(Debug, PartialEq)]
+pub struct Set {
+    pub key: String,
+    pub value: Bytes,
+}
+
+impl TryFrom<&mut CommandParser> for Set {
+    type Error = Error;
+
+    fn try_from(parser: &mut CommandParser) -> Result<Self, Self::Error> {
+        let key = parser.next_string()?;
+        let value = parser.next_bytes()?;
+
+        Ok(Self { key, value })
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -8,10 +8,10 @@ use crate::frame::Frame;
 use crate::Result;
 
 pub struct Connection {
-    stream: TcpStream,
+    pub stream: TcpStream,
     // Data is read from the socket into the read buffer. When a frame is parsed, the corresponding
     // data is removed from the buffer.
-    buffer: BytesMut,
+    pub buffer: BytesMut,
 }
 
 impl Connection {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -187,8 +187,8 @@ enum DataType {
     // The string mustn't contain a CR (\r) or LF (\n) character and is
     // terminated by CRLF (i.e., \r\n).
     // Simple strings transmit short, non-binary strings with minimal overhead.
-    BulkString,     // '$'
     SimpleString,   // '+'
+    BulkString,     // '$'
     VerbatimString, // '='
     SimpleError,    // '-'
     BulkError,      // '!'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod command;
+pub mod commands;
 pub mod connection;
 pub mod frame;
 pub mod server;


### PR DESCRIPTION
This PR adds

* Implements dummy INFO cmd. Apparently this is required by my GUI Redis client to connect to a server.
* Move each cmd to its own folder
* Listen and apply frames/commands on a loop
* Basic "OK" response for each command