### PR TITLE
Add args parsing and accept port arg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tracing-subscriber = "0.3.18"
 uuid = { version = "1.8.0", features = ["v4"] }
 strum = "0.26.2"
 strum_macros = "0.26.2"
+clap = { version = "4.5.7", features = ["derive", "env"] }
 
 [dev-dependencies]
 redis = "0.25.4"

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -5,7 +5,6 @@ const PORT: u16 = 6379;
 
 #[derive(Parser, Debug)]
 struct Args {
-    /// The port to listen on
     #[arg(short, long, default_value_t = PORT)]
     port: u16,
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -5,6 +5,7 @@ const PORT: u16 = 6379;
 
 #[derive(Parser, Debug)]
 struct Args {
+    /// The port to listen on
     #[arg(short, long, default_value_t = PORT)]
     port: u16,
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,6 +1,18 @@
+use clap::Parser;
 use rustdis::{server, Error};
+
+const PORT: u16 = 6379;
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// The port to listen on
+    #[arg(short, long, default_value_t = PORT)]
+    port: u16,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    server::run().await
+    let args = Args::parse();
+
+    server::run(args.port).await
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,13 +9,12 @@ use crate::connection::Connection;
 use crate::store::Store;
 use crate::Error;
 
-const PORT: u16 = 6378;
 
-pub async fn run() -> Result<(), Error> {
+pub async fn run(port: u16) -> Result<(), Error> {
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber)?;
 
-    let listener = TcpListener::bind(("127.0.0.1", PORT)).await?;
+    let listener = TcpListener::bind(("127.0.0.1", port)).await?;
     let store = Store::new();
 
     info!("Redis server listening on {}", listener.local_addr()?);

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,7 +9,6 @@ use crate::connection::Connection;
 use crate::store::Store;
 use crate::Error;
 
-
 pub async fn run(port: u16) -> Result<(), Error> {
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber)?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@ use rustdis::server::run;
 use tokio::time::{sleep, Duration};
 
 async fn connect() -> Result<(Connection, Connection), RedisError> {
-    tokio::spawn(async { run().await });
+    tokio::spawn(async { run(6378).await });
     sleep(Duration::from_millis(100)).await;
 
     let our_client = redis::Client::open("redis://127.0.0.1:6378/")?;


### PR DESCRIPTION
```
~/d/rustdis feat/server/port-config*
$ cargo run -- --help
   Compiling clap v4.5.7
   Compiling rustdis v0.1.1 (/Users/bb8/dev/rustdis)
    Finished dev [unoptimized + debuginfo] target(s) in 0.93s
     Running `target/debug/rustdis --help`
Usage: rustdis [OPTIONS]

Options:
  -p, --port <PORT>  The port to listen on [default: 6379]
  -h, --help         Print help
```

```
~/d/rustdis feat/server/port-config*
$ cargo run -- --port 1200
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/rustdis --port 1200`
2024-06-28T06:17:36.286554Z  INFO rustdis::server: Redis server listening on 127.0.0.1:1200
```

```
~/d/rustdis feat/server/port-config
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/rustdis`
2024-06-28T06:18:47.650002Z  INFO rustdis::server: Redis server listening on 127.0.0.1:6379
```