### PR TITLE
Update tracing setup and add more integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,7 @@ strum_macros = "0.26.2"
 clap = { version = "4.5.7", features = ["derive", "env"] }
 
 [dev-dependencies]
+rand = "0.8.5"
 redis = { version = "0.25.4", features = ["tokio-comp", "aio"] }
+serial_test = "3.1.1"
 tokio = { version = "1.35.0", features = ["full", "test-util"] }

--- a/src/commands/decrby.rs
+++ b/src/commands/decrby.rs
@@ -6,7 +6,7 @@ use crate::Error;
 
 /// Decrements the number stored at key by `decrement`.
 ///
-/// Ref: <https://redis.io/docs/latest/commands/incrby/>
+/// Ref: <https://redis.io/docs/latest/commands/decrby/>
 #[derive(Debug, PartialEq)]
 pub struct DecrBy {
     pub key: String,
@@ -18,7 +18,7 @@ impl Executable for DecrBy {
         let res = store.incr_by(&self.key, -self.decrement);
 
         match res {
-            Ok(_) => Ok(Frame::Simple("OK".to_string())),
+            Ok(value) => Ok(Frame::Integer(value)),
             Err(msg) => Ok(Frame::Error(msg.to_string())),
         }
     }
@@ -65,7 +65,7 @@ mod tests {
 
         let result = cmd.exec(store.clone()).unwrap();
 
-        assert_eq!(result, Frame::Simple("OK".to_string()));
+        assert_eq!(result, Frame::Integer(10));
         assert_eq!(store.lock().get("key1"), Some(Bytes::from("10")));
     }
 
@@ -90,7 +90,7 @@ mod tests {
 
         let result = cmd.exec(store.clone()).unwrap();
 
-        assert_eq!(result, Frame::Simple("OK".to_string()));
+        assert_eq!(result, Frame::Integer(-10));
         assert_eq!(store.lock().get("key1"), Some(Bytes::from("-10")));
     }
 

--- a/src/commands/incrby.rs
+++ b/src/commands/incrby.rs
@@ -17,7 +17,7 @@ impl Executable for IncrBy {
     fn exec(self, store: Store) -> Result<Frame, Error> {
         let res = store.incr_by(&self.key, self.increment);
         match res {
-            Ok(_) => Ok(Frame::Simple("OK".to_string())),
+            Ok(value) => Ok(Frame::Integer(value)),
             Err(msg) => Ok(Frame::Error(msg.to_string())),
         }
     }
@@ -64,7 +64,7 @@ mod tests {
 
         let result = cmd.exec(store.clone()).unwrap();
 
-        assert_eq!(result, Frame::Simple("OK".to_string()));
+        assert_eq!(result, Frame::Integer(30));
         assert_eq!(store.lock().get("key1"), Some(Bytes::from("30")));
     }
 
@@ -89,7 +89,7 @@ mod tests {
 
         let result = cmd.exec(store.clone()).unwrap();
 
-        assert_eq!(result, Frame::Simple("OK".to_string()));
+        assert_eq!(result, Frame::Integer(10));
         assert_eq!(store.lock().get("key1"), Some(Bytes::from("10")));
     }
 

--- a/src/commands/mget.rs
+++ b/src/commands/mget.rs
@@ -28,7 +28,7 @@ impl Executable for Mget {
             .map(|value| {
                 value
                     .map(|v| Frame::Bulk(v.clone()))
-                    .unwrap_or_else(|| Frame::Null)
+                    .unwrap_or_else(|| Frame::NullBulkString)
             })
             .collect::<Vec<_>>();
 
@@ -151,7 +151,7 @@ mod tests {
 
         let res = cmd.exec(store.clone()).unwrap();
 
-        assert_eq!(res, Frame::Array(vec![Frame::Null]));
+        assert_eq!(res, Frame::Array(vec![Frame::NullBulkString]));
     }
 
     #[tokio::test]
@@ -189,7 +189,7 @@ mod tests {
             res,
             Frame::Array(vec![
                 Frame::Bulk(Bytes::from("1")),
-                Frame::Null,
+                Frame::NullBulkString,
                 Frame::Bulk(Bytes::from("3"))
             ])
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,24 +9,24 @@
 //! # Architecture
 //!
 //! * `server`: Redis server module. Provides a run function that initiates the server, enabling it
-//! to begin handling incoming connections from Redis clients. It manages client requests, executes
-//! Redis commands, and handles connection lifecycles.
+//!     to begin handling incoming connections from Redis clients. It manages client requests, executes
+//!     Redis commands, and handles connection lifecycles.
 //!
 //! * `connection`: The Connection module manages a TCP connection for a Redis client. It separates
-//! the TCP stream into readable and writable components to facilitate data consumption and
-//! transmission. The server uses this connection module to read data from the TCP connection.
+//!     the TCP stream into readable and writable components to facilitate data consumption and
+//!     transmission. The server uses this connection module to read data from the TCP connection.
 //!
 //! * `codec`: This module is responsible for decoding raw TCP byte streams into `Frame` data
-//! structures. This is an essential component for translating incoming client requests into
-//! meaningful Redis commands.
+//!     structures. This is an essential component for translating incoming client requests into
+//!     meaningful Redis commands.
 //!
 //! * `frame`: This module defines the `Frame` enum, representing different types of Redis protocol
-//! messages, and provides parsing and serialization functionalities. It adheres to the RESP (Redis
-//! Serialization Protocol) specifications.
+//!     messages, and provides parsing and serialization functionalities. It adheres to the RESP (Redis
+//!     Serialization Protocol) specifications.
 //!
 //! * `store`: This module provides a simple key-value store for managing Redis string data types.
-//! It supports basic operations such as setting, getting, removing, and incrementing values
-//! associated with keys.
+//!     It supports basic operations such as setting, getting, removing, and incrementing values
+//!     associated with keys.
 //!
 //! ```text
 //!

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
-use tracing::{error, info, instrument};
+use tracing::{debug, error, info, instrument};
 
 use crate::commands::executable::Executable;
 use crate::commands::Command;
@@ -10,8 +10,9 @@ use crate::store::Store;
 use crate::Error;
 
 pub async fn run(port: u16) -> Result<(), Error> {
-    let subscriber = tracing_subscriber::FmtSubscriber::new();
-    tracing::subscriber::set_global_default(subscriber)?;
+    let _ = tracing_subscriber::fmt()
+        .try_init()
+        .map_err(|e| debug!("Failed to initialize global tracing: {}", e));
 
     let listener = TcpListener::bind(("127.0.0.1", port)).await?;
     let store = Store::new();


### PR DESCRIPTION
This PR adds:

* Run integration tests sequentially
* Update incrby/decrby response
* Update mget null response type
* Gracefully handle server startup by managing global tracing setup
* Add more integration tests